### PR TITLE
fix: deploy script of telescope extension

### DIFF
--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/full/deploy.sh
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/full/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 cd ~/jpyx-telescope
 docker-compose down
-docker pull ghcr.io/CauchyE/telescope:latest
-docker pull ghcr.io/UnUniFi/telescope-ununifi:latest
+docker pull ghcr.io/cauchye/telescope:latest
+docker pull ghcr.io/ununifi/telescope-ununifi:latest
 curl -O https://raw.githubusercontent.com/UnUniFi/utils/main/projects/telescope-extension/editions/jpyx/docker-compose.yml
 curl -O https://raw.githubusercontent.com/UnUniFi/utils/main/projects/telescope-extension/nginx.conf
 curl -O https://raw.githubusercontent.com/UnUniFi/utils/main/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/full/config.js

--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/light/deploy.sh
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/light/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 cd ~/jpyx-telescope
 docker-compose down
-docker pull ghcr.io/CauchyE/telescope:latest
-docker pull ghcr.io/UnUniFi/telescope-ununifi:latest
+docker pull ghcr.io/cauchye/telescope:latest
+docker pull ghcr.io/ununifi/telescope-ununifi:latest
 curl -O https://raw.githubusercontent.com/UnUniFi/utils/main/projects/telescope-extension/editions/jpyx/docker-compose.yml
 curl -O https://raw.githubusercontent.com/UnUniFi/utils/main/projects/telescope-extension/nginx.conf
 curl -O https://raw.githubusercontent.com/UnUniFi/utils/main/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/light/config.js

--- a/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/standard/deploy.sh
+++ b/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/standard/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 cd ~/jpyx-telescope
 docker-compose down
-docker pull ghcr.io/CauchyE/telescope:latest
-docker pull ghcr.io/UnUniFi/telescope-ununifi:latest
+docker pull ghcr.io/cauchye/telescope:latest
+docker pull ghcr.io/ununifi/telescope-ununifi:latest
 curl -O https://raw.githubusercontent.com/UnUniFi/utils/main/projects/telescope-extension/editions/jpyx/docker-compose.yml
 curl -O https://raw.githubusercontent.com/UnUniFi/utils/main/projects/telescope-extension/nginx.conf
 curl -O https://raw.githubusercontent.com/UnUniFi/utils/main/projects/telescope-extension/editions/jpyx/launch/jpyx-4-test/standard/config.js


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

デプロイ用スクリプトでのコンテナレジストリの名前の指定に大文字が使われたままだったところの修正です。