### PR TITLE
feat: add cd push docker image for private testnet

### DIFF
--- a/.github/workflows/action-trigger-docker-telescope-ununifi-private-test.yml
+++ b/.github/workflows/action-trigger-docker-telescope-ununifi-private-test.yml
@@ -1,0 +1,26 @@
+name: telescope Action Trigger Publish Docker image for Private Testnet telescope-ununifi
+on:
+  repository_dispatch:
+    types:
+      - repository-telescope-new-release-for-private-testnet
+jobs:
+  push_to_registry:
+    name: Push Docker image for Private Testnet to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./projects/telescope-extension/editions/ununifi/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/ununifi/telescope-ununifi:testnet

--- a/.github/workflows/action-trigger-docker-telescope-ununifi-private-test.yml
+++ b/.github/workflows/action-trigger-docker-telescope-ununifi-private-test.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+        with:
+          ref: develop
       - name: Log in to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/docker-pricefeed-private-test.yml
+++ b/.github/workflows/docker-pricefeed-private-test.yml
@@ -1,0 +1,30 @@
+name: Publish Docker image for Private Testnet pricefeed
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  push_to_registry:
+    name: Push Docker image for Private Testnet to ghcr.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup variables
+        id: variables
+        run: echo "::set-output name=version::${GITHUB_REF##*/}"
+      - name: Build and Push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          context: ./projects/pricefeed/
+          file: ./projects/pricefeed/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/ununifi/pricefeed:test

--- a/.github/workflows/docker-telescope-ununifi-private-test.yml
+++ b/.github/workflows/docker-telescope-ununifi-private-test.yml
@@ -1,11 +1,11 @@
-name: telescope Action Trigger Publish Docker image pricefeed
+name: Publish Docker image for Private Testnet telescope-ununifi
 on:
-  repository_dispatch:
-    types:
-      - repository-telescope-new-release
+  push:
+    branches:
+      - develop
 jobs:
   push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Push Docker image for Private Testnet to ghcr.io
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -16,11 +16,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup variables
+        id: variables
+        run: echo "::set-output name=version::${GITHUB_REF##*/}"
       - name: Build and Push to Docker Hub
         uses: docker/build-push-action@v2
         with:
-          context: ./projects/pricefeed/
-          file: ./projects/pricefeed/Dockerfile
+          context: .
+          file: ./projects/telescope-extension/editions/ununifi/Dockerfile
           push: true
           tags: |
-            ghcr.io/ununifi/pricefeed:latest
+            ghcr.io/ununifi/telescope-ununifi:test


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

developにマージされた際と、CauchyE/telescopeレポジトリで新しいPrivate Testnet用のtelescopeのDockerイメージが作成されたイベントが発火された際、Private Testnet用のDockerイメージがタグ: testで公開されるようGitHub Actionsを追加しました。