### PR TITLE
feat: delete last element divider and improve appearance of numbers and dates

### DIFF
--- a/projects/telescope-extension/src/app/views/auction/auction.component.html
+++ b/projects/telescope-extension/src/app/views/auction/auction.component.html
@@ -26,7 +26,6 @@
       <span class="flex-auto"></span>
       <span>{{ params?.increment_surplus }}</span>
     </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
   </mat-list>
 </mat-card>
 
@@ -44,7 +43,6 @@
       <span class="flex-auto"></span>
       <span>{{ params?.max_auction_duration }}</span>
     </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
   </mat-list>
 </mat-card>
 <!--<pre>{{ params | json }}</pre>-->

--- a/projects/telescope-extension/src/app/views/auction/auction.component.html
+++ b/projects/telescope-extension/src/app/views/auction/auction.component.html
@@ -12,19 +12,19 @@
     <mat-list-item>
       <span>Increment Collateral:</span>
       <span class="flex-auto"></span>
-      <span>{{ params?.increment_collateral }}</span>
+      <span>{{ params?.increment_collateral | number: '1.9-9' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
       <span>Increment Debt:</span>
       <span class="flex-auto"></span>
-      <span>{{ params?.increment_debt }}</span>
+      <span>{{ params?.increment_debt | number: '1.9-9' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
       <span>Increment Surplus:</span>
       <span class="flex-auto"></span>
-      <span>{{ params?.increment_surplus }}</span>
+      <span>{{ params?.increment_surplus | number: '1.9-9' }}</span>
     </mat-list-item>
   </mat-list>
 </mat-card>
@@ -33,7 +33,7 @@
 <mat-card>
   <mat-list>
     <mat-list-item>
-      <span>Bid Duration</span>
+      <span>Bid Duration:</span>
       <span class="flex-auto"></span>
       <span>{{ params?.bid_duration }}</span>
     </mat-list-item>

--- a/projects/telescope-extension/src/app/views/auction/auctions/auction/auction.component.html
+++ b/projects/telescope-extension/src/app/views/auction/auctions/auction/auction.component.html
@@ -73,7 +73,7 @@
         <span class="column-name"> End Time: </span>
         <span class="flex-auto"></span>
         <span class="column-value">
-          {{ endTime?.toUTCString() | date: 'yyyy-M-d a h:mm:ss z' }}
+          {{ endTime | date: 'yyyy-M-d a h:mm:ss z' }}
         </span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
@@ -82,7 +82,7 @@
         <span class="column-name"> Max End Time: </span>
         <span class="flex-auto"></span>
         <span class="column-value">
-          {{ maxEndTime?.toUTCString() | date: 'yyyy-M-d a h:mm:ss z' }}
+          {{ maxEndTime | date: 'yyyy-M-d a h:mm:ss z' }}
         </span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>

--- a/projects/telescope-extension/src/app/views/auction/auctions/auction/auction.component.html
+++ b/projects/telescope-extension/src/app/views/auction/auctions/auction/auction.component.html
@@ -73,7 +73,7 @@
         <span class="column-name"> End Time: </span>
         <span class="flex-auto"></span>
         <span class="column-value">
-          {{ endTime }}
+          {{ endTime?.toUTCString() | date: 'yyyy-M-d a h:mm:ss z' }}
         </span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
@@ -82,7 +82,7 @@
         <span class="column-name"> Max End Time: </span>
         <span class="flex-auto"></span>
         <span class="column-value">
-          {{ maxEndTime }}
+          {{ maxEndTime?.toUTCString() | date: 'yyyy-M-d a h:mm:ss z' }}
         </span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>

--- a/projects/telescope-extension/src/app/views/cdp/cdp.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdp.component.html
@@ -24,32 +24,32 @@
     <mat-list-item>
       <span>Liquidation Ratio:</span>
       <span class="flex-auto"></span>
-      <span>{{ collateral.liquidation_ratio | number:'1.6-6' }}</span>
+      <span>{{ collateral.liquidation_ratio | number: '1.6-6' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
       <span>Debt Limit:</span>
       <span class="flex-auto"></span>
-      <span>{{ collateral.debt_limit?.amount | number:'1.0-0' }}</span>
+      <span>{{ collateral.debt_limit?.amount | number: '1.0-0' }}</span>
       <span class="ml-1">{{ collateral.debt_limit?.denom }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
       <span>Stability Fee:</span>
       <span class="flex-auto"></span>
-      <span>{{ collateral.stability_fee}}</span>
+      <span>{{ collateral.stability_fee }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
       <span>Auction Size:</span>
       <span class="flex-auto"></span>
-      <span>{{ collateral.auction_size | number:'1.0-0' }}</span>
+      <span>{{ collateral.auction_size | number: '1.0-0' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
       <span>Liquidation Penalty:</span>
       <span class="flex-auto"></span>
-      <span>{{ collateral.liquidation_penalty | number:'1.6-6' }}</span>
+      <span>{{ collateral.liquidation_penalty | number: '1.6-6' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
@@ -67,13 +67,13 @@
     <mat-list-item>
       <span>Keeper Reward Percentage:</span>
       <span class="flex-auto"></span>
-      <span>{{ collateral.keeper_reward_percentage | number:'1.9-9' }}</span>
+      <span>{{ collateral.keeper_reward_percentage | number: '1.9-9' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
       <span>Check Collateralization Index Count:</span>
       <span class="flex-auto"></span>
-      <span>{{ collateral.check_collateralization_index_count | number:'1.0-0' }}</span>
+      <span>{{ collateral.check_collateralization_index_count | number: '1.0-0' }}</span>
     </mat-list-item>
     <mat-divider [inset]="true"></mat-divider>
     <mat-list-item>
@@ -121,32 +121,32 @@
     <mat-list-item>
       <span>Global Debt Limit:</span>
       <span class="flex-auto"></span>
-      <span>{{ params?.global_debt_limit?.amount | number:'1.0-0' }}</span>
+      <span>{{ params?.global_debt_limit?.amount | number: '1.0-0' }}</span>
       <span class="ml-1">{{ params?.global_debt_limit?.denom }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>
       <span>Surplus Auction Threshold:</span>
       <span class="flex-auto"></span>
-      <span>{{ params?.surplus_auction_threshold | number:'1.0-0' }}</span>
+      <span>{{ params?.surplus_auction_threshold | number: '1.0-0' }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>
       <span>Surplus Auction Lot:</span>
       <span class="flex-auto"></span>
-      <span>{{ params?.surplus_auction_lot | number:'1.0-0' }}</span>
+      <span>{{ params?.surplus_auction_lot | number: '1.0-0' }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>
       <span>Debt Auction Threshold:</span>
       <span class="flex-auto"></span>
-      <span>{{ params?.debt_auction_threshold | number:'1.0-0' }}</span>
+      <span>{{ params?.debt_auction_threshold | number: '1.0-0' }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>
       <span>Debt Auction Lot:</span>
       <span class="flex-auto"></span>
-      <span>{{ params?.debt_auction_lot | number:'1.0-0' }}</span>
+      <span>{{ params?.debt_auction_lot | number: '1.0-0' }}</span>
     </mat-list-item>
     <mat-divider></mat-divider>
     <mat-list-item>

--- a/projects/telescope-extension/src/app/views/cdp/cdp.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdp.component.html
@@ -81,7 +81,6 @@
       <span class="flex-auto"></span>
       <span>{{ collateral.conversion_factor }}</span>
     </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
   </mat-list>
 </mat-card>
 
@@ -111,7 +110,6 @@
       <span class="flex-auto"></span>
       <span>{{ params?.debt_param?.debt_floor }}</span>
     </mat-list-item>
-    <mat-divider [inset]="true"></mat-divider>
   </mat-list>
 </mat-card>
 

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.html
@@ -50,7 +50,8 @@
       <mat-list-item>
         <span class="column-name">Principal: </span>
         <span class="flex-auto"></span>
-        <span class="column-value">{{ cdp?.cdp?.principal?.amount }}
+        <span class="column-value"
+          >{{ cdp?.cdp?.principal?.amount }}
           {{ cdp?.cdp?.principal?.denom }}
           <ng-template [ngIf]="!!issueLimit">
             (Available: {{ issueLimit }} {{ cdp?.cdp?.principal?.denom }})
@@ -104,9 +105,7 @@
       <mat-list-item>
         <span class="column-name">Spot Price: </span>
         <span class="flex-auto"></span>
-        <span class="column-value">
-          {{ spotPrice?.price }} [{{ spotPrice?.market_id }}]
-        </span>
+        <span class="column-value"> {{ spotPrice?.price }} [{{ spotPrice?.market_id }}] </span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
 
@@ -134,9 +133,7 @@
       <mat-list>
         <span class="column-name">{{ deposit.depositor }}</span>
         <span class="flex-auto"></span>
-        <span class="column-value">
-          {{ deposit.amount?.amount }} {{ deposit.amount?.denom }}
-        </span>
+        <span class="column-value"> {{ deposit.amount?.amount }} {{ deposit.amount?.denom }} </span>
       </mat-list>
     </ng-template>
   </mat-card>

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.html
@@ -94,10 +94,10 @@
       <mat-divider [inset]="true"></mat-divider>
 
       <mat-list-item>
-        <span class="column-name"> Fees Updated </span>
+        <span class="column-name"> Fees Updated: </span>
         <span class="flex-auto"></span>
         <span class="column-value">
-          {{ cdp?.cdp?.fees_updated }}
+          {{ cdp?.cdp?.fees_updated | date: 'yyyy-M-d a h:mm:ss z' }}
         </span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
@@ -105,7 +105,9 @@
       <mat-list-item>
         <span class="column-name">Spot Price: </span>
         <span class="flex-auto"></span>
-        <span class="column-value"> {{ spotPrice?.price }} [{{ spotPrice?.market_id }}] </span>
+        <span class="column-value">
+          {{ spotPrice?.price | number: '1.9-9' }} [{{ spotPrice?.market_id }}]
+        </span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
 
@@ -113,7 +115,7 @@
         <span class="column-name">Liquidation Price: </span>
         <span class="flex-auto"></span>
         <span class="column-value">
-          {{ liquidationPrice?.price }} [{{ liquidationPrice?.market_id }}]
+          {{ liquidationPrice?.price | number: '1.9-9' }} [{{ liquidationPrice?.market_id }}]
         </span>
       </mat-list-item>
       <mat-divider [inset]="true"></mat-divider>
@@ -121,7 +123,7 @@
       <mat-list-item>
         <span class="column-name">Collateralization Ratio: </span>
         <span class="flex-auto"></span>
-        <span class="column-value">{{ cdp?.collateralization_ratio }}</span>
+        <span class="column-value">{{ cdp?.collateralization_ratio | number: '1.9-9' }}</span>
       </mat-list-item>
     </mat-list>
   </mat-card>

--- a/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.html
+++ b/projects/telescope-extension/src/app/views/cdp/cdps/cdp/cdp.component.html
@@ -110,7 +110,7 @@
       <mat-divider [inset]="true"></mat-divider>
 
       <mat-list-item>
-        <span class="column-name">Liquadation Price: </span>
+        <span class="column-name">Liquidation Price: </span>
         <span class="flex-auto"></span>
         <span class="column-value">
           {{ liquidationPrice?.price }} [{{ liquidationPrice?.market_id }}]
@@ -123,7 +123,6 @@
         <span class="flex-auto"></span>
         <span class="column-value">{{ cdp?.collateralization_ratio }}</span>
       </mat-list-item>
-      <mat-divider [inset]="true"></mat-divider>
     </mat-list>
   </mat-card>
 


### PR DESCRIPTION
以下修正しました。

・カード内のリストの最後の項目にボーダーラインが表示されている。⇒ `削除　　　　　　　　　　[https://github.com/CauchyE/telescope/pull/227](https://github.com/CauchyE/telescope/pull/227) と同様の修正。
その他、
・小数点以下表示を指定。
・日付表示のフォーマットをそろえる。

![20220111_pic](https://user-images.githubusercontent.com/75844498/148950090-22a9138d-a679-489f-ad44-4721374455a3.png)

ご確認お願い致します。