### PR TITLE
fix: hotfix pricefeed fee

### DIFF
--- a/projects/pricefeed/src/price-oracle.ts
+++ b/projects/pricefeed/src/price-oracle.ts
@@ -367,13 +367,13 @@ export class PriceOracle {
       const simulatedGasUsedWithMarginNumber = simulatedGasUsed
         ? parseInt(simulatedGasUsed) * 1.1
         : 200000;
-      const simulatedGasUsedWithMargin = simulatedGasUsedWithMarginNumber.toFixed(0);
+      const simulatedGasUsedWithMargin = Math.ceil(simulatedGasUsedWithMarginNumber).toString();
       const simulatedFeeWithMarginNumber =
         parseInt(simulatedGasUsedWithMargin) *
         parseFloat(
           process.env.MINIMUM_GAS_PRICE_AMOUNT ? process.env.MINIMUM_GAS_PRICE_AMOUNT : '200000',
         );
-      const simulatedFeeWithMargin = simulatedFeeWithMarginNumber.toFixed(0) + 1;
+      const simulatedFeeWithMargin = Math.ceil(simulatedFeeWithMarginNumber).toString();
       console.log({
         simulatedGasUsed,
         simulatedGasUsedWithMargin,


### PR DESCRIPTION
@KimuraYu45z 
レビューお願いします。

手数料計算の実装にて、stringな数字(例えば7) + numberな数字(例えば1) = (期待値8に対して71になってしまう)のようなアホみたいなバグを作りこんでしまっていました(-_-;)

ローカルからプライベートテストネット向けに動作させて動作確認済です。