### PR TITLE
extension ununifi-8-private-test

### DIFF
--- a/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/docker-compose.yml
+++ b/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  telescope-ununifi:
+    container_name: telescope-ununifi
+    image: ghcr.io/ununifi/telescope-ununifi:test
+    volumes:
+      - ./config.js:/usr/share/nginx/html/assets/config.js
+      - ./config.js:/usr/share/nginx/html/ununifi/assets/config.js
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    # ports:
+    #   - 80:80
+    network_mode: host
+    restart: always

--- a/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/full/config.js
+++ b/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/full/config.js
@@ -1,0 +1,76 @@
+const config = {
+  restURL: `${location.protocol}//${location.hostname}:1317`,
+  websocketURL: `${location.protocol.replace('http', 'ws')}//${location.hostname}:26657`,
+  chainID: 'ununifi-8-private-test',
+  bech32Prefix: {
+    accAddr: 'ununifi',
+    accPub: 'ununifipub',
+    valAddr: 'ununifivaloper',
+    valPub: 'ununifivaloperpub',
+    consAddr: 'ununifivalcons',
+    consPub: 'ununifivalconspub',
+  },
+  minimumGasPrices: [
+    {
+      denom: 'uguu',
+      amount: 0.015,
+    },
+  ],
+  extension: {
+    faucet: [
+      {
+        hasFaucet: true,
+        faucetURL: `${location.protocol}//${location.hostname}:8000`,
+        denom: 'ubtc',
+        creditAmount: 100, // amount to credit in max request
+        maxCredit: 99, // account has already maxCredit balance cannot claim anymore
+      },
+      {
+        hasFaucet: true,
+        faucetURL: `${location.protocol}//${location.hostname}:8002`,
+        denom: 'uguu',
+        creditAmount: 2000000,
+        maxCredit: 1999999,
+      },
+      {
+        hasFaucet: false,
+        faucetURL: `${location.protocol}//${location.hostname}:8004`,
+        denom: 'jpu',
+        creditAmount: 10,
+        maxCredit: 9,
+      },
+    ],
+    monitor: {
+      monitorURL: `${location.protocol}//${location.hostname}:9000`,
+    },
+    navigations: [
+      {
+        name: 'Monitor',
+        link: '/monitor',
+        icon: 'monitor',
+      },
+      {
+        name: 'UnUniFi',
+        link: '/ununifi/',
+        icon: 'toll',
+      },
+    ],
+    messageModules: [
+      'bank',
+      'auth',
+      'crisis',
+      'distribution',
+      'evidence',
+      'genaccounts',
+      'gov',
+      'ibc',
+      'slashing',
+      'staking',
+      'auction',
+      'ununifidist',
+      'cdp',
+      'incentive',
+      'pricefeed',
+    ],
+  },
+};

--- a/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/full/deploy.sh
+++ b/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/full/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd ~/telescope
+docker-compose down
+docker pull ghcr.io/cauchye/telescope:test
+docker pull ghcr.io/ununifi/telescope-ununifi:test
+curl -O https://raw.githubusercontent.com/UnUniFi/utils/develop/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/docker-compose.yml
+curl -O https://raw.githubusercontent.com/UnUniFi/utils/develop/projects/telescope-extension/nginx.conf
+curl -O https://raw.githubusercontent.com/UnUniFi/utils/develop/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/full/config.js
+docker-compose up -d

--- a/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/light/config.js
+++ b/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/light/config.js
@@ -1,0 +1,76 @@
+const config = {
+  restURL: `${location.protocol}//${location.hostname}:1317`,
+  websocketURL: `${location.protocol.replace('http', 'ws')}//${location.hostname}:26657`,
+  chainID: 'ununifi-8-private-test',
+  bech32Prefix: {
+    accAddr: 'ununifi',
+    accPub: 'ununifipub',
+    valAddr: 'ununifivaloper',
+    valPub: 'ununifivaloperpub',
+    consAddr: 'ununifivalcons',
+    consPub: 'ununifivalconspub',
+  },
+  minimumGasPrices: [
+    {
+      denom: 'uguu',
+      amount: 0.015,
+    }
+  ],
+  extension: {
+    faucet: [
+      {
+        hasFaucet: true,
+        faucetURL: `${location.protocol}//b.private-test.ununifi.cauchye.net:8000`, // a.test.ununifi.cauchye.net is also available.
+        denom: 'ubtc',
+        creditAmount: 100, // amount to credit in max request
+        maxCredit: 99, // account has already maxCredit balance cannot claim anymore
+      },
+      {
+        hasFaucet: true,
+        faucetURL: `${location.protocol}//b.private-test.ununifi.cauchye.net:8002`, // a.test.ununifi.cauchye.net is also available.
+        denom: 'uguu',
+        creditAmount: 2000000,
+        maxCredit: 1999999,
+      },
+      {
+        hasFaucet: false,
+        faucetURL: `${location.protocol}//b.private-test.ununifi.cauchye.net:8004`, // a.test.ununifi.cauchye.net is also available.
+        denom: 'jpu',
+        creditAmount: 10,
+        maxCredit: 9,
+      }
+    ],
+    monitor: {
+      monitorURL: `${location.protocol}//${location.hostname}:9000`,
+    },
+    navigations: [
+      {
+        name: 'Monitor',
+        link: '/monitor',
+        icon: 'monitor',
+      },
+      {
+        name: 'UnUniFi',
+        link: '/ununifi/',
+        icon: 'toll',
+      },
+    ],
+    messageModules: [
+      'bank',
+      'auth',
+      'crisis',
+      'distribution',
+      'evidence',
+      'genaccounts',
+      'gov',
+      'ibc',
+      'slashing',
+      'staking',
+      'auction',
+      'ununifidist',
+      'cdp',
+      'incentive',
+      'pricefeed',
+    ],
+  },
+};

--- a/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/light/deploy.sh
+++ b/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/light/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd ~/telescope
+docker-compose down
+docker pull ghcr.io/cauchye/telescope:test
+docker pull ghcr.io/ununifi/telescope-ununifi:test
+curl -O https://raw.githubusercontent.com/UnUniFi/utils/develop/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/docker-compose.yml
+curl -O https://raw.githubusercontent.com/UnUniFi/utils/develop/projects/telescope-extension/nginx.conf
+curl -O https://raw.githubusercontent.com/UnUniFi/utils/develop/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/light/config.js
+docker-compose up -d

--- a/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/standard/config.js
+++ b/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/standard/config.js
@@ -1,0 +1,76 @@
+const config = {
+  restURL: `${location.protocol}//${location.hostname}:1317`,
+  websocketURL: `${location.protocol.replace('http', 'ws')}//${location.hostname}:26657`,
+  chainID: 'ununifi-8-private-test',
+  bech32Prefix: {
+    accAddr: 'ununifi',
+    accPub: 'ununifipub',
+    valAddr: 'ununifivaloper',
+    valPub: 'ununifivaloperpub',
+    consAddr: 'ununifivalcons',
+    consPub: 'ununifivalconspub',
+  },
+  minimumGasPrices: [
+    {
+      denom: 'uguu',
+      amount: 0.015,
+    },
+  ],
+  extension: {
+    faucet: [
+      {
+        hasFaucet: true,
+        faucetURL: `${location.protocol}//b.private-test.ununifi.cauchye.net:8000`, // a.test.ununifi.cauchye.net is also available.
+        denom: 'ubtc',
+        creditAmount: 100, // amount to credit in max request
+        maxCredit: 99, // account has already maxCredit balance cannot claim anymore
+      },
+      {
+        hasFaucet: true,
+        faucetURL: `${location.protocol}//b.private-test.ununifi.cauchye.net:8002`, // a.test.ununifi.cauchye.net is also available.
+        denom: 'uguu',
+        creditAmount: 2000000,
+        maxCredit: 1999999,
+      },
+      {
+        hasFaucet: false,
+        faucetURL: `${location.protocol}//b.private-test.ununifi.cauchye.net:8004`, // a.test.ununifi.cauchye.net is also available.
+        denom: 'jpu',
+        creditAmount: 10,
+        maxCredit: 9,
+      },
+    ],
+    monitor: {
+      monitorURL: `${location.protocol}//${location.hostname}:9000`,
+    },
+    navigations: [
+      {
+        name: 'Monitor',
+        link: '/monitor',
+        icon: 'monitor',
+      },
+      {
+        name: 'UnUniFi',
+        link: '/ununifi/',
+        icon: 'toll',
+      },
+    ],
+    messageModules: [
+      'bank',
+      'auth',
+      'crisis',
+      'distribution',
+      'evidence',
+      'genaccounts',
+      'gov',
+      'ibc',
+      'slashing',
+      'staking',
+      'auction',
+      'ununifidist',
+      'cdp',
+      'incentive',
+      'pricefeed',
+    ],
+  },
+};

--- a/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/standard/deploy.sh
+++ b/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/standard/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd ~/telescope
+docker-compose down
+docker pull ghcr.io/cauchye/telescope:test
+docker pull ghcr.io/ununifi/telescope-ununifi:test
+curl -O https://raw.githubusercontent.com/UnUniFi/utils/develop/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/docker-compose.yml
+curl -O https://raw.githubusercontent.com/UnUniFi/utils/develop/projects/telescope-extension/nginx.conf
+curl -O https://raw.githubusercontent.com/UnUniFi/utils/develop/projects/telescope-extension/editions/ununifi/launch/ununifi-8-private-test/standard/config.js
+docker-compose up -d


### PR DESCRIPTION
@YasunoriMATSUOKA デプロイのスクリプトでテスト８用のconfig.jsが取れるように/telescope-extension/editions/ununifi/launch/ununifi-8-private-testを追加しています

念の為、develop宛先のPR作成していますが、必要なれば次回からは直接developにPushします